### PR TITLE
Fix unfortunate typo

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.Build) !void {
     const upstream = b.dependency("libressl", .{});
     const libressl_common: LibreSslCommon = .{
         .libcrypto = b.addStaticLibrary(.{
-            .name = "cypto",
+            .name = "crypto",
             .target = target,
             .optimize = optimize,
         }),


### PR DESCRIPTION
The `crypto` artifact advertised in the readme was called `cypto`.